### PR TITLE
Work-around for out of bounds error

### DIFF
--- a/core/scrape_via_login.py
+++ b/core/scrape_via_login.py
@@ -13,8 +13,7 @@ def main():
     session_requests = requests.session()
 
     # Get login csrf token
-    result = session_requests.get(LOGIN_URL)
-    tree = html.fromstring(result.text)
+    tree = etree.HTML(session_requests.get(URL).content)
     authenticity_token = list(set(tree.xpath("//meta[@name='csrf-token']/@content")))[0]
     authenticity_param = list(set(tree.xpath("//meta[@name='csrf-param']/@content")))[0]
 


### PR DESCRIPTION
You have make sure the requests in one session, so that the csrf_token will be matched
Fixes issue #20.
A similar fix is required for scrape_list_via_login.py